### PR TITLE
feat(#7) : 회원 사진 수정 시에 메인페이지로 돌아가지 않게 수정 + 회원 탈퇴 기능 추가 (#7)

### DIFF
--- a/src/apis/profile.ts
+++ b/src/apis/profile.ts
@@ -39,7 +39,8 @@ export const requestModifyProfile = (request: ModifyProfileRequest) => {
   })
 }
 
-export const patchProfile = async (payload: ModifyProfileRequest) => {
+// 개인정보 변경 시에 실행될 함수
+export const reqeustPatchProfile = async (payload: ModifyProfileRequest) => {
   const response = await defaultFetch(`${Envs.VITE_API_ENDPOINT}/api/mypage/modify`, {
     method: 'PATCH',
     headers: {
@@ -55,7 +56,8 @@ export const patchProfile = async (payload: ModifyProfileRequest) => {
   return await response.json(); // 필요 시 수정
 };
 
-export const patchImage = async (payload: FormData) => {
+// 이미지 변경 시에 사용하는 함수
+export const requestPatchImage = async (payload: FormData) => {
   const response = await defaultFetch(`${Envs.VITE_API_ENDPOINT}/api/mypage/modify/image`, {
     method: 'PATCH',
     body: payload
@@ -66,4 +68,11 @@ export const patchImage = async (payload: FormData) => {
   }
 
   return await response.json();
+}
+
+// 회원 탈퇴 시에 사용하는 함수
+export const requestWithdraw = async (id: number) => {
+  return defaultFetch(`${Envs.VITE_API_ENDPOINT}/api/oauth/deactivate/${id}`, {
+    method: 'PATCH'
+  });
 }

--- a/src/pages/MyPageModify/MyPageModify.tsx
+++ b/src/pages/MyPageModify/MyPageModify.tsx
@@ -14,22 +14,40 @@ import {
   WithdrawButton
 } from './MyPageModify.styles';
 import { useState} from "react";
-import {ModifyProfileRequest, patchProfile, PasswordFields, patchImage} from "@/apis/profile.ts";
+import {
+  ModifyProfileRequest,
+  PasswordFields,
+  reqeustPatchProfile,
+  requestPatchImage,
+  requestWithdraw
+} from '@/apis/profile.ts';
 import { useNavigate } from "react-router-dom";
 import {message} from "antd";
+import { useUserStore } from '@/stores/user.ts';
+import { removeLocalStorageItem, StorageKeys } from '@/utils/storage.ts';
+import { Paths } from '@/routes/routes.ts';
 
 export const MyPageModify =  () => {
   const navigate = useNavigate();
+  const {id} = useUserStore();
+
   const { profile, setProfile } =  useProfile();
+
+  // 비밀번호 관련 값을 담기 위한 passwords 선언
   const [passwords, setPasswords] = useState<PasswordFields>({
     password: '',
     confirmPassword: '',
   });
 
+  // 사진 파일값을 담아두기 위한 파일 선언
+  const [imageFile, setImageFile] = useState<File | null>(null);
+
+  // 값이 null이거나 undefined이거나, 공백만 있으면 true 반환
   const isEmpty = (value: string | null | undefined): boolean => {
     return !value || value.trim() === '';
   };
 
+  // 각각의 입력 필드에 대해 값을 확인한다.
   const validateModifyProfileRequest = (request: ModifyProfileRequest): string | null => {
     if (isEmpty(request.name)) return '이름을 입력해주세요.';
     if (isEmpty(request.password)) return '비밀번호를 입력해주세요.';
@@ -47,7 +65,7 @@ export const MyPageModify =  () => {
     setProfile((prev) => {
       if (!prev) return;
 
-      // 이전 값이 NUll이 아니라면, name에 해당하는 값만 바꿔서 setProfile 다시 하기
+      // 이전 값이 NUll이 아니라면, name에 해당하는 값만 바꿔서 setProfile 수행
       return {
         ...prev, [name]: value
       };
@@ -59,43 +77,58 @@ export const MyPageModify =  () => {
     // 기본적으로 name, value를 target에서 받는다
     const {name, value} = e.target;
     setPasswords((prev) => {
-      // 이전 값이 NUll이 아니라면, name에 해당하는 값만 바꿔서 setProfile 다시 하기
+      // 이전 값이 NUll이 아니라면, name 해당하는 값만 바꿔서 setPaswords 수행
       return {
         ...prev, [name]: value
       };
     });
   };
 
-  // 사진 변경 감지
+  // 사진 변경 시에 발생할 이벤트
   const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
 
-    const formData = new FormData();
-    formData.append('image', file);
-
-    console.log("업로드된 파일", file);
-    console.log("전돨된 Formdata", formData);
+    // imageFile값을 변경해둔다!
+    setImageFile(file);
 
     const imageUrl = URL.createObjectURL(file); // 브라우저에서 미리 보기 URL 생성
     setProfile((prev) => ({
       ...prev!,
       myImage: imageUrl, // 임시로 보여주기 (업로드 전 미리보기 용)
     }));
-
-    // 실제 서버 업로드는 아래처럼 비동기 함수로 구현 가능
-    await patchImage(formData);
-    navigate('/mypage')
   };
 
+  // 탈퇴 눌렀을 시에 발생할 이벤트
+  const handleWithdraw = async() => {
+
+    // 탈퇴 요청
+    const response = await requestWithdraw(id)
+
+    // 탈퇴가 잘 되었다면, 로그 모두 삭제
+    if (response.status === 200) {
+      message.info("회원 탈퇴가 완료되었습니다.")
+      removeLocalStorageItem(StorageKeys.ACCESS_TOKEN);
+      removeLocalStorageItem(StorageKeys.REFRESH_TOKEN);
+
+      // 로그인 페이지로 돌려보내기
+      navigate(Paths.SIGN_IN);
+    } else {
+      // 아니라면, 메세지 출력
+      message.error(JSON.stringify(response.json()))
+    }
+  }
+
+  // 정보 수정 버튼 눌렀을 시에 발생할 이벤트
   const submitProfile = async () => {
 
+    // ModifyProfileRequest 생성
     const request: ModifyProfileRequest = {
       name: profile?.name ?? '',
       password: passwords.password,
       nickname: profile?.nickname ?? '',
       contact: profile?.contact ?? '',
-      address: "주소모름"
+      address: "주소 알수없음"
     };
 
     // 비밀번호 서로 다른지 체크
@@ -104,6 +137,7 @@ export const MyPageModify =  () => {
       return;
     }
 
+    // 값이 모두 유효한지 체크!
     const error = validateModifyProfileRequest(request);
     if (error) {
       message.warning(error);
@@ -111,9 +145,19 @@ export const MyPageModify =  () => {
     }
 
     try {
-      await patchProfile(request);
+      // 데이터 업데이트!
+      await reqeustPatchProfile(request);
+
+      // 사진 변경이 있었다면, 사진도 업데이트
+      if (imageFile) {
+        const formData = new FormData();
+        formData.append('image', imageFile);
+
+        // 실제 서버 업로드 수행
+        await requestPatchImage(formData);
+      }
       message.success('프로필이 수정되었습니다.');
-      navigate('/mypage'); // 또는 다른 경로로 이동
+      navigate(Paths.MYPAGE); // 마이페이지로 돌려보내기
     } catch (error) {
       message.error('프로필 수정에 실패했습니다.' + error);
     }
@@ -184,7 +228,7 @@ export const MyPageModify =  () => {
               {/* 버튼 영역 */}
               <ButtonWrapper>
                 <SubmitButton onClick={() => submitProfile()}>수정 완료</SubmitButton>
-                {/* <WithdrawButton>회원 탈퇴</WithdrawButton> */}
+                <WithdrawButton onClick={() => handleWithdraw()}>회원 탈퇴</WithdrawButton>
               </ButtonWrapper>
             </Right>
           </Wrapper>


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
마이페이지에서 사진을 변경했을 때 마이페이지로 나가지지 않도록 합니다.
회원 탈퇴 기능을 활성화합니다.


# 연관 이슈 및 Close 할 이슈 작성
close #7 

# Pull Request 체크리스트

## TODO

- [x] 사진 변경하고, 제출 눌렀을 시에 변경되도록 수정
- [x] 회원 탈퇴 기능 활성화
